### PR TITLE
🐛 fix(script): remove 'raw' from SPHINX_GETTEXT_TARGETS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set(SPHINX_GETTEXT_COMPACT "0"
     # Passed to sphinx-build as -Dgettext_compact=${SPHINX_GETTEXT_COMPACT}.
     # See https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-gettext_compact for details.
 
-set(SPHINX_GETTEXT_TARGETS "index,literal-block,raw"
+set(SPHINX_GETTEXT_TARGETS "index,literal-block"
     CACHE STRING "The additional targets for Sphinx with gettext builder.")
     # Possible values are a comma-separated list of the following targets:
     # "index", "literal-block", "doctest-block", "raw", and "image".


### PR DESCRIPTION
Close: #3 

Updated the SPHINX_GETTEXT_TARGETS variable to exclude 'raw', fixing the Crowdin's 65535-byte limit.