### PR TITLE
🐛 fix(script): bootstrap pip with ensurepip

### DIFF
--- a/cmake/targets/install_requirements.cmake
+++ b/cmake/targets/install_requirements.cmake
@@ -219,6 +219,18 @@ message("")
 restore_cmake_message_indent()
 
 
+message(STATUS "Running 'python -m ensurepip' command to bootstrap the 'pip' installer...")
+remove_cmake_message_indent()
+message("")
+execute_process(
+    COMMAND ${Python_EXECUTABLE} -m ensurepip --default-pip
+    WORKING_DIRECTORY ${PROJ_OUT_REPO_DIR}
+    ECHO_OUTPUT_VARIABLE
+    ECHO_ERROR_VARIABLE)
+message("")
+restore_cmake_message_indent()
+
+
 message(STATUS "Running 'pip install' command to install 'requirements.txt'...")
 if (CMAKE_HOST_UNIX)
     set(ENV_PATH                "${PROJ_CONDA_DIR}/bin:$ENV{PATH}")


### PR DESCRIPTION
Ensure `pip` is available after installing `python` with Conda. Some local Conda setups may disable adding `pip` as a `python` dependency, and solver bugs can also skip `pip` installation. Run `python -m ensurepip` after `python` install to guarantee `pip` is present.

Synced from: https://github.com/localizethedocs/ros2-docs-l10n/commit/c9c310428a4626d3d8f8e5830ac92513a52ae767